### PR TITLE
feat(evaluator): add StructuralEvaluator with CSR computation

### DIFF
--- a/src/ai_project/evaluator/__init__.py
+++ b/src/ai_project/evaluator/__init__.py
@@ -1,0 +1,9 @@
+"""Public interface for the evaluator package."""
+
+from ai_project.evaluator.base import Evaluator
+from ai_project.evaluator.structural import StructuralEvaluator
+
+__all__ = [
+    "Evaluator",
+    "StructuralEvaluator",
+]

--- a/src/ai_project/evaluator/base.py
+++ b/src/ai_project/evaluator/base.py
@@ -1,0 +1,31 @@
+"""Abstract base class for evaluators."""
+
+from abc import ABC, abstractmethod
+
+from ai_project.constraints import Constraint
+
+
+class Evaluator(ABC):
+    """Abstract base class for message evaluators."""
+
+    @abstractmethod
+    def evaluate(
+        self,
+        message: str,
+        constraints: list[Constraint],
+    ) -> float:
+        """Evaluate how well a message satisfies a list of constraints.
+
+        Return a normalized score between 0.0 and 1.0.
+
+        Args:
+            message:
+                The generated message to evaluate.
+            constraints:
+                The constraints applied to the message.
+
+        Returns:
+            A normalized constraint satisfaction score between
+            0.0 and 1.0.
+        """
+        pass

--- a/src/ai_project/evaluator/structural.py
+++ b/src/ai_project/evaluator/structural.py
@@ -1,0 +1,34 @@
+"""Structural evaluator implementation."""
+
+from ai_project.constraints import Constraint
+from ai_project.evaluator.base import Evaluator
+
+
+class StructuralEvaluator(Evaluator):
+    """Evaluate messages using constraint satisfaction rate (CSR)."""
+
+    def evaluate(
+        self,
+        message: str,
+        constraints: list[Constraint],
+    ) -> float:
+        """Evaluate how well a message satisfies a list of constraints.
+
+        Args:
+            message:
+                The generated message to evaluate.
+            constraints:
+                The constraints applied to the message.
+
+        Returns:
+            A normalized constraint satisfaction score between
+            0.0 and 1.0.
+        """
+        if not constraints:
+            return 1.0
+
+        satisfied_constraints = sum(
+            constraint.is_satisfied(message) for constraint in constraints
+        )
+
+        return satisfied_constraints / len(constraints)

--- a/tests/evaluator/test_structural.py
+++ b/tests/evaluator/test_structural.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock
+
+from ai_project.evaluator import StructuralEvaluator
+
+
+class TestStructuralEvaluator:
+    """Test suite for StructuralEvaluator CSR computation."""
+
+    def setup_method(self):
+        """Set up a fresh evaluator instance for each test."""
+        self.evaluator = StructuralEvaluator()
+
+    def test_all_constraints_satisfied_returns_one(self):
+        """Return 1.0 when all constraints are satisfied by the message."""
+        # Arrange
+        message = "hello world"
+
+        c1 = MagicMock()
+        c1.is_satisfied.return_value = True
+
+        c2 = MagicMock()
+        c2.is_satisfied.return_value = True
+
+        constraints = [c1, c2]
+
+        # Act
+        result = self.evaluator.evaluate(message, constraints)
+
+        # Assert
+        assert result == 1.0
+        c1.is_satisfied.assert_called_once_with(message)
+        c2.is_satisfied.assert_called_once_with(message)
+
+    def test_no_constraints_satisfied_returns_zero(self):
+        """Return 0.0 when no constraints are satisfied by the message."""
+        # Arrange
+        message = "hello world"
+
+        c1 = MagicMock()
+        c1.is_satisfied.return_value = False
+
+        c2 = MagicMock()
+        c2.is_satisfied.return_value = False
+
+        constraints = [c1, c2]
+
+        # Act
+        result = self.evaluator.evaluate(message, constraints)
+
+        # Assert
+        assert result == 0.0
+
+    def test_half_constraints_satisfied_returns_half(self):
+        """Return 0.5 when half of the constraints are satisfied."""
+        # Arrange
+        message = "hello world"
+
+        c1 = MagicMock()
+        c1.is_satisfied.return_value = True
+
+        c2 = MagicMock()
+        c2.is_satisfied.return_value = False
+
+        constraints = [c1, c2]
+
+        # Act
+        result = self.evaluator.evaluate(message, constraints)
+
+        # Assert
+        assert result == 0.5
+
+    def test_empty_constraints_returns_one(self):
+        """Return 1.0 when no constraints are provided."""
+        # Arrange
+        message = "hello world"
+        constraints = []
+
+        # Act
+        result = self.evaluator.evaluate(message, constraints)
+
+        # Assert
+        assert result == 1.0


### PR DESCRIPTION
## Summary

Implements the `evaluator/` module — the component that scores how well a generated message satisfies a set of constraints.

## Changes

- `Evaluator` ABC defining `evaluate(message, constraints) -> float`
- `StructuralEvaluator` computing Constraint Satisfaction Rate (CSR)
- Edge case: empty constraints returns `1.0`
- 4 unit tests covering full, partial, zero, and empty satisfaction
- Public interface via `evaluator/__init__.py`

Closes #7