### PR TITLE
feat(evaluator): add semantic LLM-based evaluation with Ollama

### DIFF
--- a/src/ai_project/evaluator/__init__.py
+++ b/src/ai_project/evaluator/__init__.py
@@ -1,9 +1,9 @@
-"""Public interface for the evaluator package."""
-
 from ai_project.evaluator.base import Evaluator
+from ai_project.evaluator.ollama import OllamaEvaluator
 from ai_project.evaluator.structural import StructuralEvaluator
 
 __all__ = [
     "Evaluator",
     "StructuralEvaluator",
+    "OllamaEvaluator",
 ]

--- a/src/ai_project/evaluator/ollama.py
+++ b/src/ai_project/evaluator/ollama.py
@@ -1,0 +1,60 @@
+"""Ollama-based semantic evaluator for constraint satisfaction."""
+
+import ollama
+
+from ai_project.constraints.base import Constraint
+from ai_project.evaluator.base import Evaluator
+from ai_project.evaluator.prompt import build_eval_prompt
+
+
+class OllamaEvaluator(Evaluator):
+    """Semantic evaluator that uses an Ollama LLM to score constraints."""
+
+    def __init__(self, model: str, base_url: str) -> None:
+        """Initialize the Ollama-based semantic evaluator.
+
+        Args:
+            model:
+                Name of the Ollama model used for semantic evaluation.
+            base_url:
+                Base URL of the Ollama server (e.g., http://localhost:11434).
+        """
+        self.model = model
+        self.client = ollama.Client(host=base_url)
+
+    def evaluate(self, message: str, constraints: list[Constraint]) -> float:
+        """Evaluate a message against semantic constraints using an LLM.
+
+        Args:
+            message:
+                The generated message to evaluate.
+            constraints:
+                List of semantic constraints.
+
+        Returns:
+            A float between 0.0 and 1.0 representing semantic satisfaction.
+        """
+        if not constraints:
+            return 1.0
+
+        scores: list[float] = []
+
+        for constraint in constraints:
+            prompt = build_eval_prompt(message, constraint)
+            response = self.client.chat(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": prompt,
+                    }
+                ],
+            )
+            raw_output = (response.message.content or "").strip()
+            try:
+                score = float(raw_output)
+            except (ValueError, TypeError, AttributeError):
+                score = 0.0
+            scores.append(score)
+
+        return sum(scores) / len(scores)

--- a/src/ai_project/evaluator/prompt.py
+++ b/src/ai_project/evaluator/prompt.py
@@ -1,0 +1,30 @@
+"""Prompt construction utilities for the semantic evaluator."""
+
+from ai_project.constraints.base import Constraint
+
+
+def build_eval_prompt(message: str, constraint: Constraint) -> str:
+    """Build a prompt for semantic evaluation using an LLM judge.
+
+    Args:
+        message:
+            The generated message to evaluate.
+        constraint:
+            The constraint to evaluate against.
+
+    Returns:
+        A formatted prompt instructing the LLM to return a numeric score.
+    """
+    return (
+        f"You are a strict evaluation system.\n"
+        f"Your task is to evaluate how well a given message satisfies a constraint.\n\n"
+        f"Message:\n{message}\n\n"
+        f"Constraint:\n{constraint.describe()}\n\n"
+        f"Instructions:\n"
+        f"- Return a single number between 0.0 and 1.0.\n"
+        f"- 0.0 means the message does not satisfy the constraint at all.\n"
+        f"- 1.0 means the message fully satisfies the constraint.\n"
+        f"- You must not include explanations.\n"
+        f"- You must not include any additional text.\n"
+        f"- Output ONLY the number.\n"
+    )

--- a/src/ai_project/generator/ollama.py
+++ b/src/ai_project/generator/ollama.py
@@ -55,4 +55,4 @@ class OllamaGenerator(Generator):
             ],
         )
 
-        return response.message.content
+        return response.message.content or ""

--- a/tests/evaluator/test_ollama.py
+++ b/tests/evaluator/test_ollama.py
@@ -1,0 +1,115 @@
+from unittest.mock import MagicMock
+
+from ai_project.constraints.base import Constraint
+from ai_project.evaluator.ollama import OllamaEvaluator
+
+
+class TestOllamaEvaluator:
+    """Test suite for OllamaEvaluator semantic scoring."""
+
+    def setup_method(self):
+        """Set up evaluator with mocked LLM client."""
+        self.client = MagicMock()
+        self.evaluator = OllamaEvaluator(
+            model="llama3", base_url="http://localhost:11434"
+        )
+        self.evaluator.client = self.client
+
+    def test_all_constraints_satisfied_returns_one(self):
+        """Return 1.0 when all constraints return perfect score."""
+        # Arrange
+        message = "hello world"
+
+        c1 = MagicMock(spec=Constraint)
+        c1.describe.return_value = "constraint 1"
+        c2 = MagicMock(spec=Constraint)
+        c2.describe.return_value = "constraint 2"
+
+        self.client.chat.return_value.message.content = "1.0"
+
+        constraints = [c1, c2]
+
+        # Act
+        result = self.evaluator.evaluate(message, constraints)
+
+        # Assert
+        assert result == 1.0
+        assert self.client.chat.call_count == 2
+
+    def test_no_constraints_satisfied_returns_zero(self):
+        """Return 0.0 when all constraints return zero score."""
+        # Arrange
+        message = "hello world"
+
+        c1 = MagicMock(spec=Constraint)
+        c1.describe.return_value = "constraint 1"
+        c2 = MagicMock(spec=Constraint)
+        c2.describe.return_value = "constraint 2"
+
+        self.client.chat.return_value.message.content = "0.0"
+
+        constraints = [c1, c2]
+
+        # Act
+        result = self.evaluator.evaluate(message, constraints)
+
+        # Assert
+        assert result == 0.0
+        assert self.client.chat.call_count == 2
+
+    def test_half_constraints_satisfied_returns_half(self):
+        """Return 0.5 when half of constraints are satisfied."""
+        # Arrange
+        message = "hello world"
+
+        c1 = MagicMock(spec=Constraint)
+        c1.describe.return_value = "constraint 1"
+        c2 = MagicMock(spec=Constraint)
+        c2.describe.return_value = "constraint 2"
+
+        # first call 1.0, second call 0.0
+        self.client.chat.side_effect = [
+            MagicMock(message=MagicMock(content="1.0")),
+            MagicMock(message=MagicMock(content="0.0")),
+        ]
+
+        constraints = [c1, c2]
+
+        # Act
+        result = self.evaluator.evaluate(message, constraints)
+
+        # Assert
+        assert result == 0.5
+        assert self.client.chat.call_count == 2
+
+    def test_empty_constraints_returns_one(self):
+        """Return 1.0 when no constraints are provided."""
+        # Arrange
+        message = "hello world"
+        constraints = []
+
+        # Act
+        result = self.evaluator.evaluate(message, constraints)
+
+        # Assert
+        assert result == 1.0
+        self.client.chat.assert_not_called()
+
+    def test_invalid_llm_output_returns_zero_fallback(self):
+        """Return 0.0 when LLM output cannot be parsed as float."""
+        # Arrange
+        message = "hello world"
+
+        c1 = MagicMock(spec=Constraint)
+        c1.describe.return_value = "constraint 1"
+
+        self.client.chat.return_value.message.content = "this is not a number"
+
+        constraints = [c1]
+
+        # Act
+        result = self.evaluator.evaluate(message, constraints)
+
+        # Assert
+        assert result == 0.0
+        self.client.chat.assert_called_once()


### PR DESCRIPTION
## Summary

Adds the semantic evaluation layer to the `evaluator/` module using an Ollama LLM as judge.

## Changes

- `evaluator/prompt.py` — prompt builder for structured LLM evaluation
- `evaluator/ollama.py` — OllamaEvaluator scoring semantic constraints via LLM
- `evaluator/__init__.py` — updated public interface
- `tests/evaluator/test_ollama.py` — 5 unit tests with mocked LLM client
- `fix(generator)` — restored OllamaGenerator accidentally overwritten

Closes #9