### PR TITLE
feat(generator): add iterative feedback support for prompt refinement

### DIFF
--- a/src/ai_project/generator/base.py
+++ b/src/ai_project/generator/base.py
@@ -13,13 +13,19 @@ class Generator(ABC):
         self,
         topic: str,
         constraints: list[Constraint],
+        feedback: list[Constraint] | None = None,
     ) -> str:
         """Generate a message that satisfies the given constraints.
 
         Args:
-            topic: The topic or subject for the message.
-            constraints: Constraints the generated message must satisfy.
+            topic:
+                The topic or subject for the message.
+            constraints:
+                Constraints the generated message must satisfy.
+            feedback:
+                Constraints that failed in previous generation attempts.
 
         Returns:
             A generated message as a string.
         """
+        pass

--- a/src/ai_project/generator/ollama.py
+++ b/src/ai_project/generator/ollama.py
@@ -30,20 +30,30 @@ class OllamaGenerator(Generator):
         self,
         topic: str,
         constraints: list[Constraint],
+        feedback: list[Constraint] | None = None,
     ) -> str:
         """Generate a message that satisfies the given constraints.
 
-        Builds a prompt from the topic and constraints, sends it
-        to the Ollama model, and returns the generated message.
+        Builds a prompt from the topic, constraints, and optional
+        feedback from previous failed attempts. Sends it to the
+        Ollama model and returns the generated message.
 
         Args:
-            topic: The topic or subject for the generated message.
-            constraints: Constraints the generated message must satisfy.
+            topic:
+                The topic or subject for the generated message.
+            constraints:
+                Constraints the generated message must satisfy.
+            feedback:
+                Constraints that failed in previous attempts.
 
         Returns:
             The generated message as a string.
         """
-        prompt = build_prompt(topic, constraints)
+        prompt = build_prompt(
+            topic,
+            constraints,
+            feedback,
+        )
 
         response = self.client.chat(
             model=self.model,

--- a/src/ai_project/generator/prompt.py
+++ b/src/ai_project/generator/prompt.py
@@ -3,27 +3,41 @@
 from ai_project.constraints.base import Constraint
 
 
-def build_prompt(topic: str, constraints: list[Constraint]) -> str:
+def build_prompt(
+    topic: str,
+    constraints: list[Constraint],
+    feedback: list[Constraint] | None = None,
+) -> str:
     """Build a prompt for the language model.
 
-    The prompt includes the target topic and all constraint
-    descriptions in natural language form.
+    The prompt includes the target topic, all constraint
+    descriptions, and optional feedback from failed constraints.
 
     Args:
-        topic: The topic or subject for the generated message.
-        constraints: Constraints the generated message must satisfy.
+        topic:
+            The topic or subject for the generated message.
+        constraints:
+            Constraints the generated message must satisfy.
+        feedback:
+            Constraints that failed in a previous generation attempt.
 
     Returns:
         A formatted prompt string ready to send to the LLM.
     """
     rules = "\n".join(f"- {constraint.describe()}" for constraint in constraints)
-
     prompt = (
         f"Generate a message about: {topic}.\n\n"
         f"The message must follow these rules:\n"
         f"{rules}\n\n"
-        f"Respond with the message only. "
-        f"No explanations, no extra text."
     )
-
+    if feedback:
+        feedback_rules = "\n".join(
+            f"- {constraint.describe()}" for constraint in feedback
+        )
+        prompt += (
+            "Previous attempts failed to satisfy these constraints:\n"
+            f"{feedback_rules}\n\n"
+            "Improve the next response to satisfy them.\n\n"
+        )
+    prompt += "Respond with the message only. No explanations, no extra text."
     return prompt

--- a/tests/generator/test_ollama.py
+++ b/tests/generator/test_ollama.py
@@ -69,3 +69,73 @@ def test_generate_sends_prompt_with_constraints():
 
     assert "customer support" in prompt
     assert "at most 10 words" in prompt
+
+
+def test_generate_without_feedback():
+    """OllamaGenerator does not include feedback section without feedback."""
+    # Arrange
+    mock_response = MagicMock()
+    mock_response.message.content = "I can help you."
+
+    mock_client = MagicMock()
+    mock_client.chat.return_value = mock_response
+
+    generator = OllamaGenerator(
+        model="llama3.2:3b",
+        base_url="http://localhost:11434",
+    )
+
+    generator.client = mock_client
+
+    constraints = [
+        MaxWordsConstraint(10),
+    ]
+
+    # Act
+    generator.generate(
+        topic="customer support",
+        constraints=constraints,
+    )
+
+    # Assert
+    prompt = mock_client.chat.call_args.kwargs["messages"][0]["content"]
+
+    assert "Previous attempts failed" not in prompt
+
+
+def test_generate_with_feedback():
+    """OllamaGenerator includes failed constraints feedback in the prompt."""
+    # Arrange
+    mock_response = MagicMock()
+    mock_response.message.content = "I can help you."
+
+    mock_client = MagicMock()
+    mock_client.chat.return_value = mock_response
+
+    generator = OllamaGenerator(
+        model="llama3.2:3b",
+        base_url="http://localhost:11434",
+    )
+
+    generator.client = mock_client
+
+    constraints = [
+        MaxWordsConstraint(10),
+    ]
+
+    feedback = [
+        MaxWordsConstraint(5),
+    ]
+
+    # Act
+    generator.generate(
+        topic="customer support",
+        constraints=constraints,
+        feedback=feedback,
+    )
+
+    # Assert
+    prompt = mock_client.chat.call_args.kwargs["messages"][0]["content"]
+
+    assert "Previous attempts failed" in prompt
+    assert "at most 5 words" in prompt


### PR DESCRIPTION
## Summary

Extends the generator to support **self-refinement** — a standard pattern in LLM optimization systems where the generator receives explicit feedback about which constraints failed in the previous attempt, enabling targeted correction instead of blind retrying.

## Motivation

Without feedback, the generator restarts from scratch each iteration with no information about what went wrong. With feedback, the prompt includes the specific constraints that failed, allowing the LLM to produce a better candidate on the next attempt.

## Changes

- `generator/base.py` — adds optional `feedback: list[Constraint] | None` parameter to Generator ABC
- `generator/prompt.py` — appends a feedback section to the prompt when failed constraints are provided
- `generator/ollama.py` — forwards feedback parameter to `build_prompt()`
- `tests/generator/test_ollama.py` — 2 new tests verifying feedback presence and absence in prompt

## Testing

31 tests passing, 97% coverage. `generator/prompt.py` restored to 100% coverage.

Closes #11