### PR TITLE
feat(config): add settings module to load environment configuration

### DIFF
--- a/src/ai_project/config.py
+++ b/src/ai_project/config.py
@@ -1,0 +1,24 @@
+"""Application configuration settings.
+
+This module defines the application's configuration using
+pydantic-settings. Values are loaded from environment variables
+and may be overridden through a .env file.
+"""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    ollama_base_url: str
+    llm_model: str
+    max_iterations: int
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+
+settings = Settings()


### PR DESCRIPTION
## Summary
Add a settings module that reads environment variables from .env and exposes them as a typed Python object using pydantic-settings.

## Motivation
The interface and other modules need access to configuration values (model name, base URL, max iterations) without hardcoding them.

## Changes
- `config.py` — Settings class with pydantic-settings, instance `settings` exported at module level

## Testing
No unit tests — module has no logic to test. Verified by running `make test` (36 passed).

Closes #15