### PR TITLE
feat(dataset): add dataset models and predefined instance catalog

### DIFF
--- a/src/ai_project/dataset/__init__.py
+++ b/src/ai_project/dataset/__init__.py
@@ -1,0 +1,9 @@
+"""Dataset models and predefined benchmark instances."""
+
+from ai_project.dataset.catalog import INSTANCES
+from ai_project.dataset.models import Instance
+
+__all__ = [
+    "Instance",
+    "INSTANCES",
+]

--- a/src/ai_project/dataset/catalog.py
+++ b/src/ai_project/dataset/catalog.py
@@ -1,0 +1,132 @@
+"""Provides predefined benchmark instances for evaluation and testing.
+
+This module defines a collection of benchmark instances with varying
+difficulty levels. Each instance combines a topic with a set of
+constraints that generated messages must satisfy.
+"""
+
+from ai_project.constraints import (
+    ForbiddenWordConstraint,
+    MaxWordsConstraint,
+    MinWordsConstraint,
+    RequiredWordConstraint,
+)
+from ai_project.dataset.models import Instance
+
+# ---------------------------------------------------------------------------
+# Easy instances
+# ---------------------------------------------------------------------------
+
+AI_EDUCATION = Instance(
+    topic="Benefits of artificial intelligence in education",
+    constraints=[
+        MinWordsConstraint(20),
+        RequiredWordConstraint(["education"]),
+    ],
+)
+
+HEALTHY_HABITS = Instance(
+    topic="Healthy daily habits",
+    constraints=[
+        MinWordsConstraint(15),
+        RequiredWordConstraint(["health"]),
+    ],
+)
+
+RENEWABLE_ENERGY = Instance(
+    topic="Importance of renewable energy",
+    constraints=[
+        MinWordsConstraint(20),
+        RequiredWordConstraint(["energy"]),
+    ],
+)
+
+
+# ---------------------------------------------------------------------------
+# Medium instances
+# ---------------------------------------------------------------------------
+
+REMOTE_WORK = Instance(
+    topic="Advantages and challenges of remote work",
+    constraints=[
+        MinWordsConstraint(30),
+        MaxWordsConstraint(60),
+        RequiredWordConstraint(["productivity"]),
+    ],
+)
+
+CYBERSECURITY = Instance(
+    topic="Cybersecurity best practices",
+    constraints=[
+        MinWordsConstraint(25),
+        MaxWordsConstraint(50),
+        RequiredWordConstraint(["security"]),
+    ],
+)
+
+CLIMATE_CHANGE = Instance(
+    topic="Actions to mitigate climate change",
+    constraints=[
+        MinWordsConstraint(30),
+        RequiredWordConstraint(["climate", "sustainability"]),
+        MaxWordsConstraint(70),
+    ],
+)
+
+ONLINE_LEARNING = Instance(
+    topic="The impact of online learning",
+    constraints=[
+        MaxWordsConstraint(50),
+        RequiredWordConstraint(["learning"]),
+        ForbiddenWordConstraint(["boring"]),
+    ],
+)
+
+
+# ---------------------------------------------------------------------------
+# Difficult instances
+# ---------------------------------------------------------------------------
+
+SPACE_EXPLORATION = Instance(
+    topic="Future of space exploration",
+    constraints=[
+        MinWordsConstraint(40),
+        MaxWordsConstraint(70),
+        RequiredWordConstraint(["space", "innovation"]),
+        ForbiddenWordConstraint(["impossible"]),
+    ],
+)
+
+MENTAL_HEALTH = Instance(
+    topic="Raising awareness about mental health",
+    constraints=[
+        MinWordsConstraint(35),
+        MaxWordsConstraint(60),
+        RequiredWordConstraint(["mental", "support"]),
+        ForbiddenWordConstraint(["weakness"]),
+    ],
+)
+
+SUSTAINABLE_CITIES = Instance(
+    topic="Building sustainable cities",
+    constraints=[
+        MinWordsConstraint(40),
+        MaxWordsConstraint(65),
+        RequiredWordConstraint(["sustainable", "transportation"]),
+        ForbiddenWordConstraint(["pollution"]),
+    ],
+)
+
+
+INSTANCES = [
+    AI_EDUCATION,
+    HEALTHY_HABITS,
+    RENEWABLE_ENERGY,
+    REMOTE_WORK,
+    CYBERSECURITY,
+    CLIMATE_CHANGE,
+    ONLINE_LEARNING,
+    SPACE_EXPLORATION,
+    MENTAL_HEALTH,
+    SUSTAINABLE_CITIES,
+]

--- a/src/ai_project/dataset/models.py
+++ b/src/ai_project/dataset/models.py
@@ -1,0 +1,22 @@
+"""Defines dataset models used throughout the application.
+
+This module contains data structures that represent benchmark
+instances used for message generation and optimization tasks.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+from ai_project.constraints.base import Constraint
+
+
+class Instance(BaseModel):
+    """Represents a message generation instance.
+
+    An instance consists of a topic and a collection of constraints
+    that the generated message must satisfy.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    topic: str
+    constraints: list[Constraint]

--- a/tests/dataset/test_models.py
+++ b/tests/dataset/test_models.py
@@ -1,0 +1,23 @@
+"""Tests for dataset models."""
+
+import pytest
+from pydantic import ValidationError
+
+from ai_project.constraints.structural import MaxWordsConstraint
+from ai_project.dataset.models import Instance
+
+
+def test_creates_instance_with_valid_data() -> None:
+    """Creates an instance when all required fields are provided."""
+    constraint = MaxWordsConstraint(10)
+    instance = Instance(topic="Artificial Intelligence", constraints=[constraint])
+    assert instance.topic == "Artificial Intelligence"
+    assert instance.constraints == [constraint]
+
+
+def test_raises_validation_error_when_topic_is_missing() -> None:
+    """Raises a validation error when topic is not provided."""
+    with pytest.raises(ValidationError):
+        Instance(
+            constraints=[],
+        )


### PR DESCRIPTION
## Summary
Add dataset module with a typed Instance model and a catalog of 10 predefined benchmark instances grouped by difficulty.

## Motivation
The interface needs predefined instances to run experiments. The catalog covers 3 difficulty levels (easy, medium, hard) with varying constraint combinations.

## Changes
- `dataset/models.py` — Instance model with pydantic validation
- `dataset/catalog.py` — 10 predefined instances across 3 difficulty levels
- `dataset/__init__.py` — public interface
- `tests/dataset/test_models.py` — 2 unit tests for Instance validation

## Testing
38 tests passing, 93% coverage.

Closes #17