### PR TITLE
feat(interface): add CLI entry point and composition root

### DIFF
--- a/src/ai_project/interface/__main__.py
+++ b/src/ai_project/interface/__main__.py
@@ -1,0 +1,5 @@
+"""Package entry point for the command-line interface."""
+
+from ai_project.interface.main import main
+
+main()

--- a/src/ai_project/interface/main.py
+++ b/src/ai_project/interface/main.py
@@ -1,0 +1,88 @@
+"""Command-line entry point for the application.
+
+This module assembles the application's components, executes the
+optimization process for predefined dataset instances, and displays
+the generated results.
+"""
+
+from ai_project.config import settings
+from ai_project.dataset import INSTANCES
+from ai_project.evaluator.ollama import OllamaEvaluator
+from ai_project.generator.ollama import OllamaGenerator
+from ai_project.interface.optimization_result import OptimizationResult
+from ai_project.optimizer import GreedyOptimizer, Optimizer
+
+
+def build_optimizer() -> Optimizer:
+    """Build and configure the optimizer and its dependencies.
+
+    Returns:
+        A fully configured optimizer instance.
+    """
+    generator = OllamaGenerator(
+        model=settings.llm_model,
+        base_url=settings.ollama_base_url,
+    )
+    evaluator = OllamaEvaluator(
+        model=settings.llm_model,
+        base_url=settings.ollama_base_url,
+    )
+    return GreedyOptimizer(
+        generator=generator,
+        evaluator=evaluator,
+        max_iterations=settings.max_iterations,
+    )
+
+
+def run_instances(optimizer: Optimizer) -> list[OptimizationResult]:
+    """Run the optimization process for all predefined instances.
+
+    Args:
+        optimizer: Optimizer used to generate messages.
+
+    Returns:
+        A list containing the optimization result for each dataset
+        instance.
+    """
+    results: list[OptimizationResult] = []
+    for instance in INSTANCES:
+        message = optimizer.optimize(
+            topic=instance.topic,
+            constraints=instance.constraints,
+        )
+        results.append(
+            OptimizationResult(
+                instance=instance,
+                message=message,
+            )
+        )
+    return results
+
+
+def display_results(results: list[OptimizationResult]) -> None:
+    """Display optimization results in a human-readable format.
+
+    Args:
+        results: Results to display.
+    """
+    for result in results:
+        print("=" * 80)
+        print(f"Topic: {result.instance.topic}")
+        print("Constraints:")
+        for constraint in result.instance.constraints:
+            print(f"  - {constraint.describe()}")
+        print("\nGenerated Message:")
+        print(result.message)
+        print()
+    print("=" * 80)
+
+
+def main() -> None:
+    """Execute the application workflow."""
+    optimizer = build_optimizer()
+    results = run_instances(optimizer)
+    display_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ai_project/interface/optimization_result.py
+++ b/src/ai_project/interface/optimization_result.py
@@ -1,0 +1,31 @@
+"""Defines result models produced by the optimization pipeline.
+
+This module contains immutable data structures used to represent the
+outcome of message optimization. These models are intended to transfer
+results between application layers without exposing implementation
+details of the optimization process.
+"""
+
+from dataclasses import dataclass
+
+from ai_project.dataset import Instance
+
+
+@dataclass(frozen=True)
+class OptimizationResult:
+    """Represents the outcome of optimizing a dataset instance.
+
+    An optimization result associates a dataset instance with the
+    highest-scoring message generated for that instance. The object is
+    immutable to ensure that optimization results remain consistent
+    after they have been produced.
+
+    Attributes:
+        instance: Dataset instance that was optimized, including its
+            topic and associated constraints.
+        message: Best message generated for the instance according to
+            the optimization strategy and evaluation criteria.
+    """
+
+    instance: Instance
+    message: str

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1,0 +1,57 @@
+"""Tests for the application entry point."""
+
+from unittest.mock import Mock, patch
+
+from ai_project.constraints import MinWordsConstraint
+from ai_project.dataset.models import Instance
+from ai_project.interface.main import OptimizationResult, run_instances
+
+
+@patch("ai_project.interface.main.INSTANCES")
+def test_run_instances_returns_results_for_all_instances(
+    mock_instances: Mock,
+) -> None:
+    """Run optimization for all dataset instances and collect results.
+
+    The test verifies that:
+    - The optimizer is invoked once per instance.
+    - Each invocation receives the correct topic and constraints.
+    - The returned results contain the expected instance-message pairs.
+    """
+    constraint = MinWordsConstraint(10)
+    instances = [
+        Instance(
+            topic="Topic 1",
+            constraints=[constraint],
+        ),
+        Instance(
+            topic="Topic 2",
+            constraints=[constraint],
+        ),
+    ]
+    mock_instances.__iter__.return_value = iter(instances)
+    optimizer = Mock()
+    optimizer.optimize.side_effect = [
+        "Generated message 1",
+        "Generated message 2",
+    ]
+    results = run_instances(optimizer)
+    assert results == [
+        OptimizationResult(
+            instance=instances[0],
+            message="Generated message 1",
+        ),
+        OptimizationResult(
+            instance=instances[1],
+            message="Generated message 2",
+        ),
+    ]
+    assert optimizer.optimize.call_count == len(instances)
+    optimizer.optimize.assert_any_call(
+        topic=instances[0].topic,
+        constraints=instances[0].constraints,
+    )
+    optimizer.optimize.assert_any_call(
+        topic=instances[1].topic,
+        constraints=instances[1].constraints,
+    )


### PR DESCRIPTION
## Summary
Add CLI entry point and composition root for the application.

## Motivation
Closes #19

## Changes
- Add `interface/main.py` with `build_optimizer`, `run_instances`, `display_results`, and `main`
- Add `interface/optimization_result.py` with immutable `OptimizationResult` dataclass
- Add `interface/__main__.py` as package entry point for `python -m ai_project.interface`

## Testing
- Added `tests/interface/test_main.py` with test for `run_instances`
- 39 tests passing, 89% coverage