### PR TITLE
feat(experiments): add experiment runner script

### DIFF
--- a/experiments/run.py
+++ b/experiments/run.py
@@ -1,0 +1,111 @@
+"""Run benchmark experiments and persist results to disk.
+
+This script executes all benchmark instances against each evaluator
+variant, collects optimization metrics, and stores the results as a
+JSON file for subsequent analysis.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from ai_project.config import settings
+from ai_project.dataset import INSTANCES
+from ai_project.evaluator import OllamaEvaluator, StructuralEvaluator
+from ai_project.generator import OllamaGenerator
+from ai_project.optimizer import GreedyOptimizer
+
+
+def main() -> None:
+    """Execute all experiment configurations and save their results."""
+    generator = OllamaGenerator(
+        model=settings.llm_model,
+        base_url=settings.ollama_base_url,
+    )
+
+    reference_evaluator = StructuralEvaluator()
+
+    evaluators = [
+        ("structural", StructuralEvaluator()),
+        (
+            "ollama",
+            OllamaEvaluator(
+                model=settings.llm_model,
+                base_url=settings.ollama_base_url,
+            ),
+        ),
+    ]
+
+    results: list[dict] = []
+
+    for evaluator_name, evaluator in evaluators:
+        for instance in INSTANCES:
+            optimizer = GreedyOptimizer(
+                generator=generator,
+                evaluator=evaluator,
+                max_iterations=settings.max_iterations,
+            )
+
+            start_time = time.perf_counter()
+
+            run = optimizer.optimize(
+                topic=instance.topic,
+                constraints=instance.constraints,
+            )
+
+            elapsed_seconds = time.perf_counter() - start_time
+
+            optimization_score = run.score_history[-1]
+
+            final_score = reference_evaluator.evaluate(
+                run.message,
+                instance.constraints,
+            )
+
+            results.append(
+                {
+                    "evaluator": evaluator_name,
+                    "instance_name": instance.name,
+                    "difficulty": instance.difficulty,
+                    "topic": instance.topic,
+                    "optimization_score": optimization_score,
+                    "final_score": final_score,
+                    "iterations_used": run.iterations_used,
+                    "elapsed_seconds": elapsed_seconds,
+                    "score_history": list(run.score_history),
+                    "final_message": run.message,
+                    "constraints": [
+                        {
+                            "description": constraint.describe(),
+                            "satisfied": constraint.is_satisfied(
+                                run.message,
+                            ),
+                        }
+                        for constraint in instance.constraints
+                    ],
+                }
+            )
+
+    output_path = Path(__file__).parent / "results" / "results.json"
+
+    output_path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with output_path.open(
+        mode="w",
+        encoding="utf-8",
+    ) as file:
+        json.dump(
+            results,
+            file,
+            indent=2,
+            ensure_ascii=False,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ai_project/dataset/catalog.py
+++ b/src/ai_project/dataset/catalog.py
@@ -18,6 +18,8 @@ from ai_project.dataset.models import Instance
 # ---------------------------------------------------------------------------
 
 AI_EDUCATION = Instance(
+    name="ai_education",
+    difficulty="easy",
     topic="Benefits of artificial intelligence in education",
     constraints=[
         MinWordsConstraint(20),
@@ -26,6 +28,8 @@ AI_EDUCATION = Instance(
 )
 
 HEALTHY_HABITS = Instance(
+    name="healthy_habits",
+    difficulty="easy",
     topic="Healthy daily habits",
     constraints=[
         MinWordsConstraint(15),
@@ -34,6 +38,8 @@ HEALTHY_HABITS = Instance(
 )
 
 RENEWABLE_ENERGY = Instance(
+    name="renewable_energy",
+    difficulty="easy",
     topic="Importance of renewable energy",
     constraints=[
         MinWordsConstraint(20),
@@ -41,12 +47,13 @@ RENEWABLE_ENERGY = Instance(
     ],
 )
 
-
 # ---------------------------------------------------------------------------
 # Medium instances
 # ---------------------------------------------------------------------------
 
 REMOTE_WORK = Instance(
+    name="remote_work",
+    difficulty="medium",
     topic="Advantages and challenges of remote work",
     constraints=[
         MinWordsConstraint(30),
@@ -56,6 +63,8 @@ REMOTE_WORK = Instance(
 )
 
 CYBERSECURITY = Instance(
+    name="cybersecurity",
+    difficulty="medium",
     topic="Cybersecurity best practices",
     constraints=[
         MinWordsConstraint(25),
@@ -65,6 +74,8 @@ CYBERSECURITY = Instance(
 )
 
 CLIMATE_CHANGE = Instance(
+    name="climate_change",
+    difficulty="medium",
     topic="Actions to mitigate climate change",
     constraints=[
         MinWordsConstraint(30),
@@ -74,6 +85,8 @@ CLIMATE_CHANGE = Instance(
 )
 
 ONLINE_LEARNING = Instance(
+    name="online_learning",
+    difficulty="medium",
     topic="The impact of online learning",
     constraints=[
         MaxWordsConstraint(50),
@@ -82,12 +95,13 @@ ONLINE_LEARNING = Instance(
     ],
 )
 
-
 # ---------------------------------------------------------------------------
 # Difficult instances
 # ---------------------------------------------------------------------------
 
 SPACE_EXPLORATION = Instance(
+    name="space_exploration",
+    difficulty="hard",
     topic="Future of space exploration",
     constraints=[
         MinWordsConstraint(40),
@@ -98,6 +112,8 @@ SPACE_EXPLORATION = Instance(
 )
 
 MENTAL_HEALTH = Instance(
+    name="mental_health",
+    difficulty="hard",
     topic="Raising awareness about mental health",
     constraints=[
         MinWordsConstraint(35),
@@ -108,6 +124,8 @@ MENTAL_HEALTH = Instance(
 )
 
 SUSTAINABLE_CITIES = Instance(
+    name="sustainable_cities",
+    difficulty="hard",
     topic="Building sustainable cities",
     constraints=[
         MinWordsConstraint(40),
@@ -116,7 +134,6 @@ SUSTAINABLE_CITIES = Instance(
         ForbiddenWordConstraint(["pollution"]),
     ],
 )
-
 
 INSTANCES = [
     AI_EDUCATION,

--- a/src/ai_project/dataset/models.py
+++ b/src/ai_project/dataset/models.py
@@ -10,13 +10,24 @@ from ai_project.constraints.base import Constraint
 
 
 class Instance(BaseModel):
-    """Represents a message generation instance.
+    """Represents a benchmark message generation instance.
 
-    An instance consists of a topic and a collection of constraints
-    that the generated message must satisfy.
+    An instance defines a generation task together with the
+    constraints that the generated message must satisfy. Additional
+    metadata such as the instance name and difficulty level can be
+    used for experiment tracking and analysis.
+
+    Attributes:
+        name: Unique identifier for the benchmark instance.
+        difficulty: Difficulty category of the instance.
+        topic: Topic on which the message should be generated.
+        constraints: Constraints that the generated message must
+            satisfy.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    name: str
+    difficulty: str
     topic: str
     constraints: list[Constraint]

--- a/tests/dataset/test_models.py
+++ b/tests/dataset/test_models.py
@@ -10,7 +10,16 @@ from ai_project.dataset.models import Instance
 def test_creates_instance_with_valid_data() -> None:
     """Creates an instance when all required fields are provided."""
     constraint = MaxWordsConstraint(10)
-    instance = Instance(topic="Artificial Intelligence", constraints=[constraint])
+
+    instance = Instance(
+        name="test_instance",
+        difficulty="easy",
+        topic="Artificial Intelligence",
+        constraints=[constraint],
+    )
+
+    assert instance.name == "test_instance"
+    assert instance.difficulty == "easy"
     assert instance.topic == "Artificial Intelligence"
     assert instance.constraints == [constraint]
 
@@ -19,5 +28,7 @@ def test_raises_validation_error_when_topic_is_missing() -> None:
     """Raises a validation error when topic is not provided."""
     with pytest.raises(ValidationError):
         Instance(
+            name="test_instance",
+            difficulty="easy",
             constraints=[],
         )

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -20,27 +20,40 @@ def test_run_instances_returns_results_for_all_instances(
     - The returned results contain the expected instance-message pairs.
     """
     constraint = MinWordsConstraint(10)
+
     instances = [
         Instance(
+            name="instance_1",
+            difficulty="easy",
             topic="Topic 1",
             constraints=[constraint],
         ),
         Instance(
+            name="instance_2",
+            difficulty="medium",
             topic="Topic 2",
             constraints=[constraint],
         ),
     ]
+
     mock_instances.__iter__.return_value = iter(instances)
+
     optimizer = Mock()
     optimizer.optimize.side_effect = [
         OptimizationRun(
-            message="Generated message 1", iterations_used=1, score_history=(1.0,)
+            message="Generated message 1",
+            iterations_used=1,
+            score_history=(1.0,),
         ),
         OptimizationRun(
-            message="Generated message 2", iterations_used=1, score_history=(1.0,)
+            message="Generated message 2",
+            iterations_used=1,
+            score_history=(1.0,),
         ),
     ]
+
     results = run_instances(optimizer)
+
     assert results == [
         OptimizationResult(
             instance=instances[0],
@@ -51,11 +64,14 @@ def test_run_instances_returns_results_for_all_instances(
             message="Generated message 2",
         ),
     ]
+
     assert optimizer.optimize.call_count == len(instances)
+
     optimizer.optimize.assert_any_call(
         topic=instances[0].topic,
         constraints=instances[0].constraints,
     )
+
     optimizer.optimize.assert_any_call(
         topic=instances[1].topic,
         constraints=instances[1].constraints,


### PR DESCRIPTION
## Summary
Add experiment runner script and extend Instance model with name and difficulty fields.

## Motivation
Closes #23

## Changes
- Add name and difficulty fields to Instance model and catalog
- Add experiments/run.py that runs all 10 instances under StructuralEvaluator and OllamaEvaluator
- Save results to experiments/results/results.json with metrics for analysis

## Testing
- 39 tests passing, 90% coverage